### PR TITLE
Added ability to read in an MFA token.

### DIFF
--- a/awsprocesscreds/saml.py
+++ b/awsprocesscreds/saml.py
@@ -235,24 +235,24 @@ class OktaAuthenticator(GenericFormsBasedAuthenticator):
                              'password': password})
         )
         parsed = json.loads(response.text)
-        print(parsed)
-        if parsed['status'] == u'MFA_REQUIRED':
-            token = parsed['stateToken']
-            print(token)
-            v_id = parsed['_embedded']['factors'][0]['id']
-            print(v_id)
-            _VERIFY_URL = auth_url + '/factors/' + v_id + '/verify'
-            vcontent = {}
-            vcontent['stateToken'] = token
-            vcontent['passCode'] = self._password_prompter("MFA Token: ")
-            v = self._requests_session.post(
-                _VERIFY_URL,
-                headers={'Content-Type': 'application/json',
-                     'Accept': 'application/json'},
-                data=json.dumps(vcontent)
-            ) 
-            session_token = json.loads(v.text)['sessionToken'] 
-        else:
+        try: 
+            if parsed['status'] == u'MFA_REQUIRED':
+                token = parsed['stateToken']
+                v_id = parsed['_embedded']['factors'][0]['id']
+                _VERIFY_URL = auth_url + '/factors/' + v_id + '/verify'
+                vcontent = {}
+                vcontent['stateToken'] = token
+                vcontent['passCode'] = self._password_prompter("MFA Token: ")
+                v = self._requests_session.post(
+                    _VERIFY_URL,
+                    headers={'Content-Type': 'application/json',
+                        'Accept': 'application/json'},
+                    data=json.dumps(vcontent)
+                ) 
+                session_token = json.loads(v.text)['sessionToken'] 
+            else:
+                session_token = parsed['sessionToken']
+        except KeyError:
             session_token = parsed['sessionToken']
         saml_url = endpoint + '?sessionToken=%s' % session_token
         response = self._requests_session.get(saml_url)

--- a/awsprocesscreds/saml.py
+++ b/awsprocesscreds/saml.py
@@ -259,12 +259,7 @@ class OktaAuthenticator(GenericFormsBasedAuthenticator):
         response = self._requests_session.get(saml_url)
         logger.info(
             'Received HTTP response of status code: %s', response.status_code)
-        r = self._extract_saml_assertion_from_response(response.text)
-        logger.info(
-            'Received the following SAML assertion: \n%s', r,
-            extra={'is_saml_assertion': True}
-        )
-        return r
+        return self._extract_saml_assertion_from_response(response.text)
 
     def is_suitable(self, config):
         return (config.get('saml_authentication_type') == 'form' and

--- a/awsprocesscreds/saml.py
+++ b/awsprocesscreds/saml.py
@@ -235,7 +235,7 @@ class OktaAuthenticator(GenericFormsBasedAuthenticator):
                              'password': password})
         )
         parsed = json.loads(response.text)
-        try: 
+        try:
             if parsed['status'] == u'MFA_REQUIRED':
                 token = parsed['stateToken']
                 v_id = parsed['_embedded']['factors'][0]['id']
@@ -245,11 +245,13 @@ class OktaAuthenticator(GenericFormsBasedAuthenticator):
                 vcontent['passCode'] = self._password_prompter("MFA Token: ")
                 v = self._requests_session.post(
                     _VERIFY_URL,
-                    headers={'Content-Type': 'application/json',
-                        'Accept': 'application/json'},
+                    headers={
+                        'Content-Type': 'application/json',
+                        'Accept': 'application/json'
+                    },
                     data=json.dumps(vcontent)
-                ) 
-                session_token = json.loads(v.text)['sessionToken'] 
+                )
+                session_token = json.loads(v.text)['sessionToken']
             else:
                 session_token = parsed['sessionToken']
         except KeyError:

--- a/awsprocesscreds/saml.py
+++ b/awsprocesscreds/saml.py
@@ -237,14 +237,13 @@ class OktaAuthenticator(GenericFormsBasedAuthenticator):
         parsed = json.loads(response.text)
         try:
             if parsed['status'] == u'MFA_REQUIRED':
-                token = parsed['stateToken']
-                v_id = parsed['_embedded']['factors'][0]['id']
-                _VERIFY_URL = auth_url + '/factors/' + v_id + '/verify'
+                verify_url = auth_url + '/factors/' + \
+                    parsed['_embedded']['factors'][0]['id'] + '/verify'
                 vcontent = {}
-                vcontent['stateToken'] = token
+                vcontent['stateToken'] = parsed['stateToken']
                 vcontent['passCode'] = self._password_prompter("MFA Token: ")
                 v = self._requests_session.post(
-                    _VERIFY_URL,
+                    verify_url,
                     headers={
                         'Content-Type': 'application/json',
                         'Accept': 'application/json'


### PR DESCRIPTION
*Issue #13 *

*Description of changes:*

I've parsed the first authentication response, and upon finding MFA_REQUIRED, sends another request with the passcode and sessionToken to return a one-time-code; this then continues the normal flow of the application.

_Limitations - this will always select the first MFA token_ . (as this resolves my use case).  Will add additional functionality for multiple MFA selection and create a new issue to do so.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
