### PR TITLE
add F5 provider support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,8 +38,8 @@ arguments:
 
 * ``-e / --endpoint`` - Your SAML idp endpoint.
 * ``-u / --username`` - Your SAML username.
-* ``-p / --provider`` - The name of your SAML provider. Currently okta and
-  adfs are supported.
+* ``-p / --provider`` - The name of your SAML provider. Currently okta, f5
+  and adfs are supported.
 * ``-a / --role-arn``- The role arn you wish to assume. Your SAML provider
   must be configured to give you access to this arn.
 
@@ -55,11 +55,20 @@ To configure this provider, you need create a profile using the
 for more details on this config option.
 
 
+
 Example okta configuration::
 
     [profile okta]
     region = us-west-2
     credential_process = awsprocesscreds-saml -e https://example.okta.com/home/amazon_aws/blob/123 -u 'monty@example.com' -p okta -a arn:aws:iam::123456789012:role/okta-dev
+
+
+Example f5 configuration::
+
+    [profile f5]
+    region = us-west-2
+    credential_process = awsprocesscreds-saml -e https://sso.example.com/aws -u 'monty' -p f5 -a arn:aws:iam::123456789012:role/f5-dev
+
 
 Example adfs configuration::
 

--- a/awsprocesscreds/cli.py
+++ b/awsprocesscreds/cli.py
@@ -26,7 +26,7 @@ def saml(argv=None, prompter=getpass.getpass, client_creator=None,
         help='Your SAML username.'
     )
     parser.add_argument(
-        '-p', '--provider', required=True, choices=['okta', 'adfs'],
+        '-p', '--provider', required=True, choices=['okta', 'adfs', 'f5'],
         help=(
             'The name of your SAML provider. Currently okta and adfs '
             'form-based auth is supported.'

--- a/awsprocesscreds/saml.py
+++ b/awsprocesscreds/saml.py
@@ -151,9 +151,9 @@ class GenericFormsBasedAuthenticator(SAMLAuthenticator):
         if login_form_html_node is None:
             raise SAMLError(self._ERROR_NO_FORM % endpoint)
 
-        my_action = login_form_html_node.attrib.get('action', '')
-        if my_action:
-            form_action = urljoin(endpoint, my_action)
+        parsed_form_action = login_form_html_node.attrib.get('action', '')
+        if parsed_form_action:
+            form_action = urljoin(endpoint, parsed_form_action)
         else:
             form_action = response.url
         if not form_action.lower().startswith('https://'):

--- a/tests/unit/test_saml.py
+++ b/tests/unit/test_saml.py
@@ -83,6 +83,7 @@ def f5_config():
         'saml_provider': 'f5',
     }
 
+
 @pytest.fixture
 def mock_authenticator():
     return mock.Mock(spec=SAMLAuthenticator)
@@ -488,8 +489,7 @@ class TestF5Authenticator(object):
         }
         assert not f5_auth.is_suitable(config)
 
-    def test_uses_f5_fields(self, f5_auth, mock_requests_session,
-                              f5_config):
+    def test_uses_f5_fields(self, f5_auth, mock_requests_session, f5_config):
         f5_login_form = (
             '<html>'
             '<form>'
@@ -499,7 +499,8 @@ class TestF5Authenticator(object):
             '</html>'
         )
         mock_requests_session.get.return_value = mock.Mock(
-            spec=requests.Response, status_code=200, text=f5_login_form, url='https://example.com/my.policy'
+            spec=requests.Response, status_code=200, text=f5_login_form,
+            url='https://example.com/my.policy'
         )
         mock_requests_session.post.return_value = mock.Mock(
             spec=requests.Response, status_code=200, text=(

--- a/tests/unit/test_saml.py
+++ b/tests/unit/test_saml.py
@@ -98,14 +98,6 @@ def basic_form():
 
 
 @pytest.fixture
-def actionless_form():
-    return (
-        '<form>'
-        '<input name="spam" value="eggs"/>'
-        '</form>'
-    )
-
-@pytest.fixture
 def cache():
     return {}
 


### PR DESCRIPTION
Fixes #22 

Our F5 SAML implementation is a generic SAML implementation, but the form does not have an "action"

This makes the form action optional and implements an F5 provider in case there are future differences between F5 and ADFS.

This is the first time I have made a PR on GitHub as well as the first time I have used  many of the python tools required to contribute to this project, so I apologize if I have have done anything wrong.  Any feedback would be much appreciated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
