### PR TITLE
35 defensive html parsing

### DIFF
--- a/awsprocesscreds/saml.py
+++ b/awsprocesscreds/saml.py
@@ -157,7 +157,8 @@ class GenericFormsBasedAuthenticator(SAMLAuthenticator):
         if not form_action.lower().startswith('https://'):
             raise SAMLError('Your SAML IdP must use HTTPS connection')
         payload = dict((tag.attrib['name'], tag.attrib.get('value', ''))
-                       for tag in login_form_html_node.findall(".//input"))
+                       for tag in login_form_html_node.findall(
+                           ".//input[@name]"))
         return form_action, payload
 
     def _assert_non_error_response(self, response):
@@ -287,7 +288,8 @@ class FormParser(six.moves.html_parser.HTMLParser):
         # so that the output will be suitable to be fed into an ET later.
         parts = []
         for k, v in d.items():
-            escaped_value = escape(v)  # pylint: disable=deprecated-method
+            escaped_value = escape(  # pylint: disable=deprecated-method
+                v) if v is not None else None
             parts.append('%s="%s"' % (k, escaped_value))
         return ' '.join(sorted(parts))
 

--- a/tests/unit/test_saml.py
+++ b/tests/unit/test_saml.py
@@ -258,6 +258,73 @@ class TestSAMLGenericFormsBasedAuthenticator(object):
             }
         )
 
+    def test_input_missing_name_attribute(self, generic_auth,
+                                          generic_config,
+                                          mock_requests_session):
+        saml_form = (
+            '<html>'
+            '<form action="/path/login/">'
+            '<input debug="true"/>'
+            '<input name="spam" value="eggs"/>'
+            '<input name="username"/>'
+            '<input name="password"/>'
+            '</form>'
+            '</html>'
+        )
+        mock_requests_session.get.return_value = mock.Mock(
+            spec=requests.Response, status_code=200, text=saml_form
+        )
+        mock_requests_session.post.return_value = mock.Mock(
+            spec=requests.Response, status_code=200, text=(
+                '<form><input name="SAMLResponse" '
+                'value="fakeassertion"/></form>'
+            )
+        )
+        saml_assertion = generic_auth.retrieve_saml_assertion(generic_config)
+        assert saml_assertion == 'fakeassertion'
+
+        mock_requests_session.post.assert_called_with(
+            "https://example.com/path/login/", verify=True,
+            data={
+                'username': 'monty',
+                'password': 'mypassword',
+                'spam': 'eggs'
+            }
+        )
+
+    def test_boolean_presence_attribute(self, generic_auth,
+                                        generic_config,
+                                        mock_requests_session):
+        saml_form = (
+            '<html>'
+            '<form action="/path/login/">'
+            '<input boolean-attr name="spam" value="eggs"/>'
+            '<input name="username"/>'
+            '<input name="password"/>'
+            '</form>'
+            '</html>'
+        )
+        mock_requests_session.get.return_value = mock.Mock(
+            spec=requests.Response, status_code=200, text=saml_form
+        )
+        mock_requests_session.post.return_value = mock.Mock(
+            spec=requests.Response, status_code=200, text=(
+                '<form><input name="SAMLResponse" '
+                'value="fakeassertion"/></form>'
+            )
+        )
+        saml_assertion = generic_auth.retrieve_saml_assertion(generic_config)
+        assert saml_assertion == 'fakeassertion'
+
+        mock_requests_session.post.assert_called_with(
+            "https://example.com/path/login/", verify=True,
+            data={
+                'username': 'monty',
+                'password': 'mypassword',
+                'spam': 'eggs'
+            }
+        )
+
     def test_error_getting_form(self, generic_auth, mock_requests_session,
                                 generic_config):
         mock_requests_session.get.return_value = mock.Mock(

--- a/tests/unit/test_saml.py
+++ b/tests/unit/test_saml.py
@@ -292,13 +292,13 @@ class TestSAMLGenericFormsBasedAuthenticator(object):
             }
         )
 
-    def test_boolean_presence_attribute(self, generic_auth,
+    def test_boolean_attribute_handling(self, generic_auth,
                                         generic_config,
                                         mock_requests_session):
         saml_form = (
             '<html>'
             '<form action="/path/login/">'
-            '<input boolean-attr name="spam" value="eggs"/>'
+            '<input attr-is-true name="spam" value="eggs"/>'
             '<input name="username"/>'
             '<input name="password"/>'
             '</form>'


### PR DESCRIPTION
*Issue #, if available:*
35

*Description of changes:*
Two problems trying to use this module on our internal login page - neither of them were coding issues with our page but were instead standard HTML entities not being parsed like they should have been.

I added two tests for the issues I found and then added in the code to fix them.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
