### PR TITLE
#11 - add multiple form field names for use with different ADFS versions

### DIFF
--- a/awsprocesscreds/saml.py
+++ b/awsprocesscreds/saml.py
@@ -175,13 +175,17 @@ class GenericFormsBasedAuthenticator(SAMLAuthenticator):
 
     def _fill_in_form_values(self, config, form_data):
         username = config['saml_username']
-        username_field = set(self.USERNAME_FIELDS).intersection(form_data.keys())
+        username_field = set(self.USERNAME_FIELDS).intersection(
+            form_data.keys()
+        )
         if not username_field:
             raise SAMLError(
                 self._ERROR_MISSING_FORM_FIELD % self.USERNAME_FIELDS)
-        else:
-            form_data[username_field.pop()] = username
-        password_field = set(self.PASSWORD_FIELDS).intersection(form_data.keys())
+        form_data[username_field.pop()] = username
+
+        password_field = set(self.PASSWORD_FIELDS).intersection(
+            form_data.keys()
+        )
         if password_field:
             form_data[password_field.pop()] = self._password_prompter(
                 "Password: ")
@@ -252,17 +256,27 @@ class OktaAuthenticator(GenericFormsBasedAuthenticator):
         return r
 
     def is_suitable(self, config):
-        return (config.get('saml_authentication_type') == 'form' and
-                config.get('saml_provider') == 'okta')
+        return (
+            config.get('saml_authentication_type') == 'form'
+            and config.get('saml_provider') == 'okta'
+        )
 
 
 class ADFSFormsBasedAuthenticator(GenericFormsBasedAuthenticator):
-    USERNAME_FIELDS = ('ctl00$ContentPlaceHolder1$UsernameTextBox', 'UserName',)
-    PASSWORD_FIELDS = ('ctl00$ContentPlaceHolder1$PasswordTextBox', 'Password',)
+    USERNAME_FIELDS = (
+        'ctl00$ContentPlaceHolder1$UsernameTextBox',
+        'UserName',
+    )
+    PASSWORD_FIELDS = (
+        'ctl00$ContentPlaceHolder1$PasswordTextBox',
+        'Password',
+    )
 
     def is_suitable(self, config):
-        return (config.get('saml_authentication_type') == 'form' and
-                config.get('saml_provider') == 'adfs')
+        return (
+            config.get('saml_authentication_type') == 'form'
+            and config.get('saml_provider') == 'adfs'
+        )
 
 
 class FormParser(six.moves.html_parser.HTMLParser):

--- a/awsprocesscreds/saml.py
+++ b/awsprocesscreds/saml.py
@@ -57,8 +57,8 @@ class SAMLAuthenticator(object):
 
 
 class GenericFormsBasedAuthenticator(SAMLAuthenticator):
-    USERNAME_FIELD = 'username'
-    PASSWORD_FIELD = 'password'
+    USERNAME_FIELDS = ('username',)
+    PASSWORD_FIELDS = ('password',)
 
     _ERROR_BAD_RESPONSE = (
         'Received a non-200 response (%s) when making a request to: %s'
@@ -175,13 +175,15 @@ class GenericFormsBasedAuthenticator(SAMLAuthenticator):
 
     def _fill_in_form_values(self, config, form_data):
         username = config['saml_username']
-        if self.USERNAME_FIELD not in form_data:
+        username_field = set(self.USERNAME_FIELDS).intersection(form_data.keys())
+        if not username_field:
             raise SAMLError(
-                self._ERROR_MISSING_FORM_FIELD % self.USERNAME_FIELD)
+                self._ERROR_MISSING_FORM_FIELD % self.USERNAME_FIELDS)
         else:
-            form_data[self.USERNAME_FIELD] = username
-        if self.PASSWORD_FIELD in form_data:
-            form_data[self.PASSWORD_FIELD] = self._password_prompter(
+            form_data[username_field.pop()] = username
+        password_field = set(self.PASSWORD_FIELDS).intersection(form_data.keys())
+        if password_field:
+            form_data[password_field.pop()] = self._password_prompter(
                 "Password: ")
 
     def _send_form_post(self, login_url, form_data):
@@ -255,8 +257,8 @@ class OktaAuthenticator(GenericFormsBasedAuthenticator):
 
 
 class ADFSFormsBasedAuthenticator(GenericFormsBasedAuthenticator):
-    USERNAME_FIELD = 'ctl00$ContentPlaceHolder1$UsernameTextBox'
-    PASSWORD_FIELD = 'ctl00$ContentPlaceHolder1$PasswordTextBox'
+    USERNAME_FIELDS = ('ctl00$ContentPlaceHolder1$UsernameTextBox', 'UserName',)
+    PASSWORD_FIELDS = ('ctl00$ContentPlaceHolder1$PasswordTextBox', 'Password',)
 
     def is_suitable(self, config):
         return (config.get('saml_authentication_type') == 'form' and


### PR DESCRIPTION
*Issue #, if available:*
#11

*Description of changes:*
Keeps the original ADFS form names, and adds in the alternate `UserName` and `Password` fields for compatibility with other login forms.  Note that this implementation allows for combinations that aren't expected (old + new form names).

Includes a new unit test for checking the alternate names.

This also includes some minor styling updates to allow `make prcheck` pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
